### PR TITLE
Make sure scriptExecutionContext stays around when invoking listeners

### DIFF
--- a/LayoutTests/js/frame-application-cache-with-listener-crash-expected.txt
+++ b/LayoutTests/js/frame-application-cache-with-listener-crash-expected.txt
@@ -1,0 +1,2 @@
+This test passes if WebKit does not crash or hit any assertions
+

--- a/LayoutTests/js/frame-application-cache-with-listener-crash.html
+++ b/LayoutTests/js/frame-application-cache-with-listener-crash.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<script>
+function runTest()
+{
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+
+    iframe.contentWindow.applicationCache.addEventListener("checking", () => {
+        document.body.appendChild(iframe);
+        document.body.innerHTML = 'This test passes if WebKit does not crash or hit any assertions';
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, {capture: true, passive: true});
+}
+</script>
+<body onload="runTest()">
+<iframe id="iframe" src="data:text/html,foo"></iframe>
+<div id="container">
+</body>

--- a/Source/WebCore/loader/appcache/DOMApplicationCache.cpp
+++ b/Source/WebCore/loader/appcache/DOMApplicationCache.cpp
@@ -87,10 +87,10 @@ void DOMApplicationCache::abort()
 
 ScriptExecutionContext* DOMApplicationCache::scriptExecutionContext() const
 {
-    auto* frame = this->frame();
-    if (!frame)
+    auto* window = this->window();
+    if (!window)
         return nullptr;
-    return frame->document();
+    return window->document();
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 0571f29b0e530dccd8e133952de9a04aebf4917f
<pre>
Make sure scriptExecutionContext stays around when invoking listeners
<a href="https://bugs.webkit.org/show_bug.cgi?id=247380">https://bugs.webkit.org/show_bug.cgi?id=247380</a>

Reviewed by NOBODY (OOPS!).

This change fixes DOMApplicationCache::scriptExecutionContext to get the
correct scriptExecutionContext by getting it from the window instead of
the frame because the frame can move when invoking listeners, in which
case the scriptExecutionContext will become NULL

* LayoutTests/js/frame-application-cache-with-listener-crash-expected.txt: Added.
* LayoutTests/js/frame-application-cache-with-listener-crash.html: Added.
* Source/WebCore/loader/appcache/DOMApplicationCache.cpp:
(WebCore::DOMApplicationCache::scriptExecutionContext const):
</pre>